### PR TITLE
Manage mentees of a mentor

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ import EditMentorApplication from './scenes/Home/scenes/EditMentorApplication';
 import RequestMentors from './scenes/Home/scenes/RequestMentors';
 import axios, { AxiosResponse } from 'axios';
 import { notification } from 'antd';
+import ManageMentees from './scenes/Home/scenes/ManageMentees';
 export const UserContext = createContext<Partial<Profile>>({});
 
 function App() {
@@ -31,7 +32,7 @@ function App() {
         setUser(response.data);
       })
       .catch((error) => {
-        if (error.reponse.status != 401) {
+        if (error.response.status != 401) {
           notification.error({
             message: 'Something went wrong when fetching the user',
             description: error.toString(),
@@ -58,6 +59,7 @@ function App() {
             path="/program/:programId/mentor/edit"
             component={EditMentorApplication}
           />
+          <Route path="/mentor/program/:programId" component={ManageMentees} />
           <Route path="/program/:programId" component={RequestMentors} />
         </Switch>
       </Router>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,12 @@ export interface Mentor {
   prerequisites: string;
 }
 
+export interface Mentee {
+  id: number;
+  profile: Profile;
+  state: string;
+}
+
 export interface Application {
   application: string;
   prerequisites: string;

--- a/src/scenes/Home/scenes/ManageMentees/components/MenteeRow/components/StatusTag/index.tsx
+++ b/src/scenes/Home/scenes/ManageMentees/components/MenteeRow/components/StatusTag/index.tsx
@@ -1,0 +1,17 @@
+import { Tag } from 'antd';
+import React from 'react';
+
+function StatusTag(props: { state: string }) {
+  switch (props.state) {
+    case 'PENDING':
+      return <Tag color="blue">PENDING</Tag>;
+    case 'APPROVED':
+      return <Tag color="green">APPROVED</Tag>;
+    case 'REJECTED':
+      return <Tag color="orange">REJECTED</Tag>;
+    default:
+      return null;
+  }
+}
+
+export default StatusTag;

--- a/src/scenes/Home/scenes/ManageMentees/components/MenteeRow/index.tsx
+++ b/src/scenes/Home/scenes/ManageMentees/components/MenteeRow/index.tsx
@@ -1,0 +1,126 @@
+import { Mentee } from '../../../../../../interfaces';
+import React, { ReactNode, useState } from 'react';
+import { Avatar, Button, List, Modal, notification } from 'antd';
+import { WarningOutlined } from '@ant-design/icons';
+import StatusTag from './components/StatusTag';
+import axios, { AxiosResponse } from 'axios';
+
+function MenteeRow(props: { mentee: Mentee, programState: string }) {
+  const actions: ReactNode[] = [];
+  const [menteeState, setMenteeState] = useState<string>(props.mentee.state);
+
+  const updateMenteeState = (isApproved: boolean) => {
+    let successMessage = '';
+    let errorMessage = '';
+
+    if (isApproved) {
+      successMessage = 'Mentee has been approved';
+      errorMessage = "Couldn't approve the mentee";
+    } else {
+      successMessage = 'Mentee has been rejected';
+      errorMessage = "Couldn't reject the mentee";
+    }
+
+    axios
+      .put(
+        `http://localhost:8080/mentees/${props.mentee.id}/state`,
+        {
+          isApproved: isApproved,
+        },
+        {
+          withCredentials: true,
+        }
+      )
+      .then((result: AxiosResponse<Mentee>) => {
+        if (result.status == 200) {
+          setMenteeState(result.data.state);
+          notification.success({
+            message: 'Success!',
+            description: successMessage,
+          });
+        } else {
+          throw new Error();
+        }
+      })
+      .catch(() => {
+        notification.error({
+          message: 'Error!',
+          description: errorMessage,
+        });
+      });
+  };
+
+  const confirmRejection = () => {
+    Modal.confirm({
+      title: 'Do you want to reject this mentee?',
+      icon: <WarningOutlined />,
+      content: 'Please confirm below, This action can be changed later.',
+      onOk() {
+        updateMenteeState(false);
+      },
+    });
+  };
+
+  const confirmApproval = () => {
+    Modal.confirm({
+      title: 'Do you want to approve this mentee?',
+      icon: <WarningOutlined />,
+      content: 'Please confirm below, This action can be changed later.',
+      onOk() {
+        updateMenteeState(true);
+      },
+    });
+  };
+
+  if (props.programState === 'MENTEE_SELECTION') {
+    const isApproveDisabled: boolean = menteeState == 'APPROVED';
+    const isRejectDisabled: boolean = menteeState == 'REJECTED';
+
+    actions.push(
+      <Button
+        key="approve"
+        type="primary"
+        disabled={isApproveDisabled}
+        onClick={confirmApproval}
+      >
+        Approve
+      </Button>
+    );
+
+    actions.push(
+      <Button
+        key="reject"
+        type="primary"
+        danger
+        disabled={isRejectDisabled}
+        onClick={confirmRejection}
+      >
+        Reject
+      </Button>
+    );
+  }
+
+  return (
+    <List.Item key={props.mentee.id} actions={[actions]}>
+      <List.Item.Meta
+        avatar={<Avatar src={props.mentee.profile.imageUrl} />}
+        title={
+          <div>
+            <a
+              href={props.mentee.profile.linkedinUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {props.mentee.profile.firstName} {props.mentee.profile.lastName}
+            </a>
+            <br />
+            <StatusTag state={props.mentee.state} />
+          </div>
+        }
+        description={props.mentee.profile.headline}
+      />
+    </List.Item>
+  );
+}
+
+export default MenteeRow;

--- a/src/scenes/Home/scenes/ManageMentees/index.tsx
+++ b/src/scenes/Home/scenes/ManageMentees/index.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { Typography, List, notification, Spin, Empty, Row, Col } from 'antd';
+import { Mentee, SavedProgram } from '../../../../interfaces';
+import { useParams } from 'react-router';
+import axios, { AxiosResponse } from 'axios';
+import styles from '../../styles.css';
+import MenteeRow from './components/MenteeRow';
+
+const { Title } = Typography;
+
+function ManageMentees() {
+  const { programId } = useParams();
+  const [mentees, setMentees] = useState<Mentee[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [program, setProgram] = useState<SavedProgram | null>(null);
+  const [shouldLoadMentees, setShouldLoadMentees] = useState<boolean>(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+    getProgram();
+  }, []);
+
+  const getProgram = () => {
+    axios
+      .get(`http://localhost:8080/programs/${programId}`, {
+        withCredentials: true,
+      })
+      .then((result: AxiosResponse<SavedProgram>) => {
+        if (result.status == 200) {
+          setProgram(result.data);
+          const shouldLoadMentees =
+            result.data.state == 'MENTEE_APPLICATION' ||
+            result.data.state == 'MENTEE_SELECTION' ||
+            result.data.state == 'ONGOING';
+          setShouldLoadMentees(shouldLoadMentees);
+          if (shouldLoadMentees) {
+            getMentees();
+          } else {
+            setIsLoading(false);
+          }
+        } else {
+          throw new Error();
+        }
+      })
+      .catch(() => {
+        setIsLoading(false);
+        notification.error({
+          message: 'Error!',
+          description: 'Something went wrong when fetching the program detail',
+        });
+      });
+  };
+
+  const getMentees = () => {
+    axios
+      .get(`http://localhost:8080/me/programs/${programId}/mentees`, {
+        withCredentials: true,
+      })
+      .then((result: AxiosResponse<Mentee[]>) => {
+        if (result.status == 200 || result.status == 204) {
+          setMentees(result.data);
+          setIsLoading(false);
+        } else {
+          throw new Error();
+        }
+      })
+      .catch(() => {
+        setIsLoading(false);
+        notification.error({
+          message: 'Error!',
+          description: 'Something went wrong when fetching the mentees',
+        });
+      });
+  };
+
+  return (
+    <div className={styles.container}>
+      <Spin tip="Loading..." spinning={isLoading}>
+        <Row>
+          <Col md={3} />
+          <Col md={15}>
+            <Title>Manage Mentees</Title>
+            {!shouldLoadMentees && program != null && (
+              <Empty
+                image="https://gw.alipayobjects.com/zos/antfincdn/ZHrcdLPrvN/empty.svg"
+                imageStyle={{
+                  height: 60,
+                }}
+                description={
+                  <span>You are currently in {program.state} state.</span>
+                }
+              />
+            )}
+            {shouldLoadMentees && (
+              <List
+                itemLayout="horizontal"
+                size="large"
+                pagination={{
+                  pageSize: 8,
+                }}
+                dataSource={mentees}
+                renderItem={(mentee: Mentee) => (
+                  <MenteeRow
+                    key={mentee.id}
+                    mentee={mentee}
+                    programState={program.state}
+                  />
+                )}
+              />
+            )}
+          </Col>
+        </Row>
+      </Spin>
+    </div>
+  );
+}
+export default ManageMentees;


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #47 

## Goals
- To create a view for mentors to handle their mentees for all life cycle states

## Approach
There are 7 states in a program. The view is different based on the state.

1. CREATED - Since none of the mentees applied, it should be blank.
2. MENTOR_APPLICATION - Since none of the mentees applied, it should be blank.
3. MENTOR_SELECTION - Since none of the mentees applied, it should be blank.
4. MENTEE_APPLICATION - All approved mentors will be able to see the mentees who have applied for him.
5. MENTEE_SELECTION - The mentor gets 2 options at this stage. Either approve or reject.
6. ONGOING - This is similar to the 4th view
7. COMPLETED - This view will be blank as there aren't any actions required.
In order to deal with the multiple views and their actions, switch statements were used to render the actions.

## Screen Recording
![Screencast from 11-17-2020 12_40_56 AM](https://user-images.githubusercontent.com/60275681/99298465-bfd7bd80-286f-11eb-808a-feba2ae2d36c.gif)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
