### PR TITLE
Implement Past Programs Tab

### DIFF
--- a/src/scenes/Home/components/PastPrograms/index.tsx
+++ b/src/scenes/Home/components/PastPrograms/index.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Col, notification, Row, Spin, Typography } from 'antd';
+import styles from '../../styles.css';
+import axios, { AxiosResponse } from 'axios';
+import { SavedProgram } from '../../../../interfaces';
+
+const { Paragraph, Title } = Typography;
+
+function PastPrograms() {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [programs, setPrograms] = useState<SavedProgram[]>([]);
+
+  useEffect(() => {
+    getPrograms();
+  }, []);
+
+  const getPrograms = () => {
+    setIsLoading(true);
+    axios
+      .get('http://localhost:8080/programs', { withCredentials: true })
+      .then((response: AxiosResponse<SavedProgram[]>) => {
+        setPrograms(response.data);
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        setIsLoading(false);
+        notification.error({
+          message: error.toString(),
+          description: 'Something went wrong when fetching the program',
+        });
+      });
+  };
+
+  return (
+    <Spin tip="Loading..." spinning={isLoading}>
+      <Row gutter={[16, 16]}>
+        {programs.map((program: SavedProgram) => (
+          <>
+            {program.state === 'COMPLETED' ? (
+              <Col md={6} key={program.id}>
+                <Card
+                  className={styles.card}
+                  bordered={false}
+                  cover={<img alt={program.title} src={program.imageUrl} />}
+                >
+                  <Row>
+                    <Col span={13}>
+                      <Title level={4}>
+                        <a
+                          target={'_blank'}
+                          rel={'noreferrer'}
+                          href={program.landingPageUrl}
+                        >
+                          {program.title}
+                        </a>
+                      </Title>
+                    </Col>
+                  </Row>
+                  <Paragraph>{program.headline}</Paragraph>
+                </Card>
+              </Col>
+            ) : null}
+          </>
+        ))}
+      </Row>
+    </Spin>
+  );
+}
+
+export default PastPrograms;

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -6,6 +6,7 @@ import { Col, Row, Tabs, Typography } from 'antd';
 import MentorPrograms from './components/MentorPrograms';
 import MenteePrograms from './components/MenteePrograms';
 import ActivePrograms from './components/ActivePrograms';
+import PastPrograms from './components/PastPrograms';
 import { UserContext } from '../../index';
 import { Profile } from '../../interfaces';
 
@@ -56,6 +57,11 @@ const Home = () => {
                 </TabPane>
               </>
             )}
+            <TabPane tab="Past Programs" key="pastPrograms">
+              <div className={styles.cardWrapper}>
+                <PastPrograms />
+              </div>
+            </TabPane>
           </Tabs>
         </Col>
       </Row>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #80

## Goals
New Tab was created to have completed programs in separate tabs

## Approach
Added a new Tab component to display only the COMPLETED state programs

## Screenshots
![Past Programs](https://user-images.githubusercontent.com/52714282/110251219-9caf5600-7fa5-11eb-96f0-2e021ddcd15d.PNG)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Google Chrome - Version 88.0.4324.190
Windows 10