### PR TITLE
Add signout option for the users

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const API_URL = 'http://localhost:8080/api';
-export const AUTH_URL = 'http://localhost:8080//oauth2/authorization/linkedin';
+export const AUTH_URL = 'http://localhost:8080/login';
+export const LOGOUT_URL = 'http://localhost:8080/logout';

--- a/src/scenes/Dashboard/index.tsx
+++ b/src/scenes/Dashboard/index.tsx
@@ -22,6 +22,7 @@ import ChangeState from './scenes/ChangeState';
 import { Profile } from '../../interfaces';
 import { UserContext } from '../../index';
 import LogInModal from '../../components /LogInModal';
+import { LOGOUT_URL } from '../../constants';
 
 const { Content, Sider, Header } = Layout;
 
@@ -76,7 +77,9 @@ function Dashboard() {
                 }
               >
                 <Menu.ItemGroup title={localStorage.username}>
-                  <Menu.Item disabled={true}>Logout</Menu.Item>
+                  <Menu.Item>
+                    <a href={LOGOUT_URL}>logout</a>
+                  </Menu.Item>
                 </Menu.ItemGroup>
               </Menu.SubMenu>
             </Menu>

--- a/src/scenes/Home/components/NavigationBar/index.tsx
+++ b/src/scenes/Home/components/NavigationBar/index.tsx
@@ -4,7 +4,7 @@ import styles from './styles.css';
 import { UserContext } from '../../../../index';
 import { Profile } from '../../../../interfaces';
 import logo from '../../scholarx.png';
-import { AUTH_URL } from '../../../../constants';
+import { AUTH_URL, LOGOUT_URL } from '../../../../constants';
 
 const NavigationBar = () => {
   const user: Partial<Profile | null> = useContext(UserContext);
@@ -15,7 +15,16 @@ const NavigationBar = () => {
         Home
       </Button>
       {user != null ? (
-        <Avatar src={user.imageUrl} className={styles.loginComponents} />
+        <>
+          <Button
+            className={styles.loginComponents}
+            href={LOGOUT_URL}
+            type={'text'}
+          >
+            logout
+          </Button>
+          <Avatar src={user.imageUrl} className={styles.loginComponents} />
+        </>
       ) : (
         <a href={AUTH_URL}>
           <Button type="primary" className={styles.loginComponents}>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #98 fix #112 

## Goals
To add the logout feature to the app

## Approach
- Added a new button to the navigation bar
- Updated the existing logout button to function on the admin dashboard
- Changed `AUTH_URL` to `http://localhost:8080/login`
- Added a new constant variable `LOGOUT_URL` with the value `http://localhost:8080/logout`

#### NOTE: Backend would only be updated for this to properly work once these commits are merged
- [Make Program endpoints public](https://github.com/Gravewalker666/scholarx/commit/8ff4419e3e80956f5fce5ee4ca4e8542b7ee2fdd)
- [Configure and handle redirection on login and logout](https://github.com/Gravewalker666/scholarx/commit/919aaee072bca237da8ca7307ae06575c23ed6de)

## Screenshots
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/45477334/115497442-4c583300-a289-11eb-8879-7206897b0e99.png">


##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
- Safari
- webpack dev server
- macOS Big Sur
