### PR TITLE
Prevent rejected mentors from getting the manage mentees option

### DIFF
--- a/src/scenes/Dashboard/index.tsx
+++ b/src/scenes/Dashboard/index.tsx
@@ -39,11 +39,11 @@ function Dashboard() {
           collapsedWidth="0"
         >
           <div>
-            <Link to="/dashboard/home">
+            <a href="/">
               <div className={styles.logo}>
                 <img src={logo} alt="SEF Logo" />
               </div>
-            </Link>
+            </a>
           </div>
           <Menu theme="dark" mode="inline">
             <Menu.Item key="1">

--- a/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/index.tsx
+++ b/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Button, Card, Col, Row, Typography } from 'antd';
+import styles from '../../../../styles.css';
+import { MentorProgramCardProps } from './interfaces';
+
+const { Paragraph, Title, Text } = Typography;
+
+function MentorProgramCard(props: MentorProgramCardProps) {
+  return (
+    <Col md={6} key={props.program.id}>
+      <Card
+        className={styles.card}
+        bordered={false}
+        cover={<img alt={props.program.title} src={props.program.imageUrl} />}
+      >
+        <Row>
+          <Col span={13}>
+            <Title level={4}>
+              <a
+                target={'_blank'}
+                rel={'noreferrer'}
+                href={props.program.landingPageUrl}
+              >
+                {props.program.title}
+              </a>
+            </Title>
+          </Col>
+          <Col span={11} className={styles.programActionButton}>
+            {props.isRejected ? (
+              <Text type={'danger'}>Rejected</Text>
+            ) : (
+              <Button type="primary" href={props.href}>
+                {props.buttonText}
+              </Button>
+            )}
+          </Col>
+        </Row>
+        <Paragraph>{props.program.headline}</Paragraph>
+      </Card>
+    </Col>
+  );
+}
+
+export default MentorProgramCard;

--- a/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/interfaces.ts
+++ b/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/interfaces.ts
@@ -1,0 +1,8 @@
+import { SavedProgram } from '../../../../../../interfaces';
+
+export interface MentorProgramCardProps {
+  program: SavedProgram;
+  href?: string;
+  buttonText?: string;
+  isRejected: boolean;
+}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #115 fix #118 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- To prevent rejected mentors from getting the manage mentees option
- To make a way for users to get back into the homepage from the admin dashboard

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Updated the existing fetch mentor programs method to fetch programs by a given enrolment state parameter
- Called it three times to get `PENDING`, `APPROVED`, and `REJECTED` programs
- Rendered the fetched programs accordingly using a new `MentorProgramCard` component

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/45477334/115993387-2962b180-a5f0-11eb-8c82-1dbec8775950.png">
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/45477334/115993356-06380200-a5f0-11eb-9e85-6e98ddaf88de.png">


##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
- Safari
- Web Pack Dev Server
- macOS Big Sur

