### PR TITLE
Remove admin menu mentee questions button

### DIFF
--- a/src/scenes/Dashboard/index.tsx
+++ b/src/scenes/Dashboard/index.tsx
@@ -74,11 +74,6 @@ function Dashboard() {
                 <ProfileOutlined /> Mentor Questions
               </Link>
             </Menu.Item>
-            <Menu.Item key="6">
-              <Link to={`/dashboard/${programId}/mentee-questions`}>
-                <ProfileOutlined /> Mentee Questions
-              </Link>
-            </Menu.Item>
           </Menu>
         </Sider>
         <Layout>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #168 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- To make the mentee question view inaccessible for the admins 

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Removed the admin menu `Mentee Questions` button

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
<img width="1679" alt="image" src="https://user-images.githubusercontent.com/45477334/120962956-6341de80-c77e-11eb-8cd2-79165ba77268.png">

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested -->
- webpack dev server
- Safari
- macOS Big Sur 
