### PR TITLE
Prevent admins from adding questions in wrong program states

### DIFF
--- a/src/scenes/Dashboard/scenes/MentorQuestions/components/AddQuestions/index.tsx
+++ b/src/scenes/Dashboard/scenes/MentorQuestions/components/AddQuestions/index.tsx
@@ -4,6 +4,7 @@ import axios, { AxiosResponse } from 'axios';
 import { Button, Table, Row, Col, Input, Spin, notification, Form } from 'antd';
 import { API_URL } from '../../../../../../constants';
 import { Question } from '../../../../../../interfaces';
+import { AddQuestionsProps } from './interfaces';
 import styles from '../../../styles.css';
 
 const columns = [
@@ -14,7 +15,7 @@ const columns = [
   },
 ];
 
-function AddQuestions() {
+function AddQuestions({ isProgramStateValid }: AddQuestionsProps) {
   const { programId } = useParams();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -83,21 +84,23 @@ function AddQuestions() {
 
   return (
     <Spin tip="Loading..." spinning={isLoading}>
-      <Row gutter={16} className={styles.marginBottom}>
-        <Col span={24}>
-          <Form onFinish={addQuestion}>
-            <Form.Item name="question">
-              <Input
-                allowClear={true}
-                placeholder="Ex: What is your highest level of education?"
-              />
-            </Form.Item>
-            <Button type="primary" htmlType="submit">
-              Add
-            </Button>
-          </Form>
-        </Col>
-      </Row>
+      {isProgramStateValid && (
+        <Row gutter={16} className={styles.marginBottom}>
+          <Col span={24}>
+            <Form onFinish={addQuestion}>
+              <Form.Item name="question">
+                <Input
+                  allowClear={true}
+                  placeholder="Ex: What is your highest level of education?"
+                />
+              </Form.Item>
+              <Button type="primary" htmlType="submit">
+                Add
+              </Button>
+            </Form>
+          </Col>
+        </Row>
+      )}
       <Table
         columns={columns}
         dataSource={questions}

--- a/src/scenes/Dashboard/scenes/MentorQuestions/components/AddQuestions/interfaces.ts
+++ b/src/scenes/Dashboard/scenes/MentorQuestions/components/AddQuestions/interfaces.ts
@@ -1,0 +1,3 @@
+export interface AddQuestionsProps {
+  isProgramStateValid: boolean;
+}

--- a/src/scenes/Dashboard/scenes/MentorQuestions/index.tsx
+++ b/src/scenes/Dashboard/scenes/MentorQuestions/index.tsx
@@ -1,39 +1,80 @@
-import React, { useState } from 'react';
-import { Typography, Row, Col, Switch } from 'antd';
+import React, { useEffect, useState } from 'react';
+import { Typography, Row, Col, Spin, Switch, notification } from 'antd';
 import AddQuestions from './components/AddQuestions';
 import EditQuestions from './components/EditQuestions';
 import styles from '../styles.css';
+import axios from 'axios';
+import { API_URL } from '../../../../constants';
+import { useParams } from 'react-router';
 
 const { Title } = Typography;
 
 function MentorQuestions() {
+  const { programId } = useParams();
   const [isEditOn, setIsEditOn] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isProgramStateValid, setIsProgramStateValid] = useState<boolean>(true);
+
+  useEffect(() => {
+    setIsLoading(true);
+    getProgramState();
+  }, []);
+
+  const getProgramState = () => {
+    axios({
+      method: 'get',
+      url: `${API_URL}/programs/${programId}`,
+      withCredentials: true,
+    })
+      .then((result) => {
+        if (result.status == 200) {
+          setIsProgramStateValid(result.data.state === 'CREATED');
+          setIsLoading(false);
+        } else {
+          throw new Error();
+        }
+      })
+      .catch(() => {
+        notification.warning({
+          message: 'Warning!',
+          description: 'Something went wrong when fetching the program',
+        });
+      });
+  };
 
   const onSwitch = (checked: boolean) => {
     setIsEditOn(checked);
   };
 
   return (
-    <Row>
-      <Col span={23}>
-        <Row>
-          <Col span={20}>
-            <Title>Mentor Questions</Title>
-          </Col>
-          <Col offset={2} span={2} className={styles.switchWrapper}>
-            <Switch
-              className={styles.switch}
-              checkedChildren="Edit"
-              unCheckedChildren="Add"
-              onChange={onSwitch}
-            />
-          </Col>
-        </Row>
-        <div className={styles.marginTop}>
-          {isEditOn ? <EditQuestions /> : <AddQuestions />}
-        </div>
-      </Col>
-    </Row>
+    <Spin tip="Loading..." spinning={isLoading}>
+      <Row>
+        <Col span={23}>
+          <Row>
+            <Col span={20}>
+              <Title>Mentor Questions</Title>
+            </Col>
+            {isProgramStateValid && (
+              <Col offset={2} span={2} className={styles.switchWrapper}>
+                <Switch
+                  className={styles.switch}
+                  checkedChildren="Edit"
+                  unCheckedChildren="Add"
+                  onChange={onSwitch}
+                />
+              </Col>
+            )}
+          </Row>
+          <div className={styles.marginTop}>
+            {isEditOn ? (
+              <EditQuestions />
+            ) : (
+              <AddQuestions isProgramStateValid={isProgramStateValid} />
+            )}
+          </div>
+        </Col>
+      </Row>
+    </Spin>
   );
 }
 


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #176

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
Prevent admins from adding questions after passing the `CREATED` program state.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
Hide the add/edit toggle button when the program is not in the `CREATED` state
Hide the `add question` text field when the program is not in the `CREATED` state

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
![Screen-Recording-2021-06-09-at-1](https://user-images.githubusercontent.com/27498587/121331306-61218080-c934-11eb-9ca2-5a58daef66ef.gif)

(gif is bit large, it may take some time to load)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs
<!--- List any other related PRs --> 
N/A

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
MacOS 11.04
OpenJDK version 1.8.0_292

## Learning
<!--- Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem. -->
N/A