### PR TITLE
Remove 'My mentor' button from mentor view

### DIFF
--- a/src/scenes/Home/components/ActivePrograms/index.tsx
+++ b/src/scenes/Home/components/ActivePrograms/index.tsx
@@ -168,15 +168,16 @@ function ActivePrograms() {
                           </Button>
                         )}
                       {program.state === 'MENTOR_CONFIRMATION' &&
-                        !isUserAdmin &&
-                        user != null && (
-                          <Button
-                            type="primary"
-                            href={`/program/${program.id}/mentor/confirmation`}
-                          >
-                            My mentor
-                          </Button>
-                        )}
+                      !isUserAdmin &&
+                      user != null &&
+                      !mentoringPrograms.length ? (
+                        <Button
+                          type="primary"
+                          href={`/program/${program.id}/mentor/confirmation`}
+                        >
+                          My mentor
+                        </Button>
+                      ) : null}
                     </Col>
                   </Row>
                   {program.state === 'MENTOR_SELECTION' && !isUserAdmin && (
@@ -189,6 +190,13 @@ function ActivePrograms() {
                       Mentee Selection Period
                     </Tag>
                   )}
+                  {program.state === 'MENTOR_CONFIRMATION' &&
+                  !isUserAdmin &&
+                  mentoringPrograms.length ? (
+                    <Tag className={styles.tag} color="green">
+                      Mentor Confirmation Period
+                    </Tag>
+                  ) : null}
                   <Paragraph>{program.headline}</Paragraph>
                 </Card>
               </Col>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #179 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- To display My mentor button only for the mentee in `Mentor-Conformation` state

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- If the user is a mentee in the program the "My Mentor" button will be displayed.
- If it's a mentor, a tag will be displayed.

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
- Mentee View
<img width="1680" alt="Screenshot 2021-06-29 at 11 46 03" src="https://user-images.githubusercontent.com/27630091/123746681-97b54000-d8cf-11eb-861f-da25e36b8e30.png">

- Mentor View
<img width="1680" alt="Screenshot 2021-06-29 at 11 47 00" src="https://user-images.githubusercontent.com/27630091/123746807-c3382a80-d8cf-11eb-9e20-56ee36c70c86.png">

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
Browser: Safari 14.0.1
IDE: IntelliJ IDEA
OS: macOS BigSur