### PR TITLE
Display Mentor Confirmation tag when user is null (Mentor Confirmation state)

### DIFF
--- a/src/scenes/Home/components/ActivePrograms/index.tsx
+++ b/src/scenes/Home/components/ActivePrograms/index.tsx
@@ -192,7 +192,7 @@ function ActivePrograms() {
                   )}
                   {program.state === 'MENTOR_CONFIRMATION' &&
                   !isUserAdmin &&
-                  mentoringPrograms.length ? (
+                  (mentoringPrograms.length || user === null) ? (
                     <Tag className={styles.tag} color="green">
                       Mentor Confirmation Period
                     </Tag>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #201

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- Display 'Mentor Confirmation Period' tag when the program is in Mentor Confirmation state and the user is null (not logged in)
## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Add a condition to display the tag when the user is null and the program state is `Mentor Confirmation`.

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
Approved Mentor's View
- Mentee View
![Screenshot 2021-07-16 at 14 26 40](https://user-images.githubusercontent.com/27630091/125921699-276a9953-d5ca-4c85-a93f-d91ed6b03bb7.png)

- Mentor View
![Screenshot 2021-07-16 at 14 19 42](https://user-images.githubusercontent.com/27630091/125920653-8220c0b0-fa4c-40b3-a81c-d0f1ceaedb04.png)

- User View
![Screenshot 2021-07-16 at 14 20 55](https://user-images.githubusercontent.com/27630091/125920878-ca7702e8-fbc9-473b-927e-78cfc9b70fad.png)

- User(not logged)
![Screenshot 2021-07-16 at 14 18 22](https://user-images.githubusercontent.com/27630091/125920515-1e18bdaf-f7c1-463e-a235-eeb014e499db.png)


##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
OS: macOS BigSur
Browser: Safari 14.0.1
IDE: IntelliJ IDEA