### PR TITLE
Hide manage button in mentee-applcation state

### DIFF
--- a/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/index.tsx
+++ b/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/index.tsx
@@ -10,6 +10,7 @@ const { Paragraph, Title, Text } = Typography;
 function MentorProgramCard({
   program,
   buttonText,
+  state,
   isRejected,
   href,
 }: MentorProgramCardProps) {
@@ -39,13 +40,12 @@ function MentorProgramCard({
             </Title>
           </Col>
           <Col span={11} className={styles.programActionButton}>
-            {isRejected ? (
-              <Text type={'danger'}>Rejected</Text>
-            ) : (
+            {isRejected ? <Text type={'danger'}>Rejected</Text> : null}
+            {state !== 'MENTEE_APPLICATION' && !isRejected ? (
               <Button type="primary" href={href}>
                 {buttonText}
               </Button>
-            )}
+            ) : null}
           </Col>
         </Row>
         <Paragraph>{program.headline}</Paragraph>

--- a/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/interfaces.ts
+++ b/src/scenes/Home/components/MentorPrograms/components/MentorProgramCard/interfaces.ts
@@ -5,4 +5,13 @@ export interface MentorProgramCardProps {
   href?: string;
   buttonText?: string;
   isRejected: boolean;
+  state:
+    | 'CREATED'
+    | 'MENTOR_APPLICATION'
+    | 'MENTOR_SELECTION'
+    | 'MENTEE_APPLICATION'
+    | 'MENTEE_SELECTION'
+    | 'MENTOR_CONFIRMATION'
+    | 'ONGOING'
+    | 'COMPLETED';
 }

--- a/src/scenes/Home/components/MentorPrograms/index.tsx
+++ b/src/scenes/Home/components/MentorPrograms/index.tsx
@@ -150,6 +150,7 @@ function MentorPrograms() {
               href={`/program/${program.id}/mentor/edit`}
               buttonText={'Edit Application'}
               isRejected={false}
+              state={program.state}
             />
           ))}
           {approvedMentorPrograms.map((program: SavedProgram) => (
@@ -159,6 +160,7 @@ function MentorPrograms() {
               href={`/mentor/program/${program.id}`}
               buttonText={'Manage'}
               isRejected={false}
+              state={program.state}
             />
           ))}
           {rejectedMentorPrograms.map((program: SavedProgram) => (
@@ -166,6 +168,7 @@ function MentorPrograms() {
               key={program.id}
               program={program}
               isRejected={true}
+              state={program.state}
             />
           ))}
         </Row>


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #204

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- Prevent displaying the "Manage" button to the mentor in the Mentee-application state.
## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Add a condition to the button, to hide the Manage button while in the 'Mentee Application' state.

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
![mentorCard](https://user-images.githubusercontent.com/27630091/126374053-fcad7dfe-aec4-44f2-8e82-263bbc25fca7.gif)

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
OS: macOS BigSur
Browser: Safari 14.0.1
IDE: IntelliJ IIDEA