### PR TITLE
Add Google Analytics to track page views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.20.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
+        "react-ga": "^3.3.0",
         "react-router-dom": "^5.2.0"
       },
       "devDependencies": {
@@ -5266,6 +5267,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -9508,6 +9510,15 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "node_modules/react-ga": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.6.2 || ^16.0 || ^17"
       }
     },
     "node_modules/react-hot-loader": {
@@ -20407,6 +20418,12 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
       }
+    },
+    "react-ga": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+      "requires": {}
     },
     "react-hot-loader": {
       "version": "4.12.21",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "axios": "^0.20.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-ga": "^3.3.0",
     "react-router-dom": "^5.2.0"
   },
   "lint-staged": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { notification } from 'antd';
 import axios, { AxiosResponse } from 'axios';
 import ReactDOM from 'react-dom';
 import 'antd/dist/antd.less';
+import ReactGA from 'react-ga';
 import {
   BrowserRouter as Router,
   Switch,
@@ -22,6 +23,9 @@ import RequestMentors from './scenes/Home/scenes/RequestMentors';
 import { Profile } from './types';
 
 export const UserContext = createContext<Partial<Profile>>({});
+
+// Initialize Google Analytics (Works with Universal Analytics (UA) Tracking ID)
+ReactGA.initialize('UA-167873271-3');
 
 function App() {
   const [user, setUser] = useState<Profile | null>(null);

--- a/src/scenes/Home/index.tsx
+++ b/src/scenes/Home/index.tsx
@@ -1,9 +1,10 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 import { Col, Row, Tabs, Typography } from 'antd';
 
 import { UserContext } from '../../index';
 import { Profile } from '../../types';
+import { trackPageWithGoogleAnalytics } from '../../util/google-analytics';
 import ActivePrograms from './components/ActivePrograms';
 import CompletedPrograms from './components/CompletedPrograms';
 import Footer from './components/Footer';
@@ -18,6 +19,10 @@ const { TabPane } = Tabs;
 const { Paragraph } = Typography;
 
 const Home = () => {
+  useEffect(() => {
+    trackPageWithGoogleAnalytics();
+  }, []);
+
   const user: Partial<Profile | null> = useContext(UserContext);
   return (
     <>

--- a/src/util/google-analytics.ts
+++ b/src/util/google-analytics.ts
@@ -1,0 +1,8 @@
+import ReactGA from 'react-ga';
+
+/**
+ * Tracks visited page path with Google Analytics.
+ */
+export const trackPageWithGoogleAnalytics = () => {
+  ReactGA.pageview(window.location.pathname + window.location.search);
+};


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #227

## Goals
Implement Google Analytics to track page views.

## Approach
- Installed `react-ga` library
- Created Universal Analytics tracking ID for project. (`react-ga` doesn't work for GA4 tags)
- Implemented utility function `trackPageWithGoogleAnalytics` at `utils/google-analytics.ts`
- Called function on home page load

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
MacOS Big Sur
Google Chrome
