### PR TITLE
Migrate mentee API calls to mentee-services

### DIFF
--- a/src/scenes/Home/scenes/ManageMentees/components/MenteeRow/index.tsx
+++ b/src/scenes/Home/scenes/ManageMentees/components/MenteeRow/index.tsx
@@ -2,10 +2,10 @@ import React, { ReactNode, useState } from 'react';
 
 import { WarningOutlined } from '@ant-design/icons';
 import { Avatar, Button, List, Modal, notification } from 'antd';
-import axios, { AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
 
-import { API_URL } from '../../../../../../constants';
 import { Mentee } from '../../../../../../types';
+import { updateStateOfMenteeApplication } from '../../../../../../util/mentee-services';
 import StatusTag from './components/StatusTag';
 import { StatusTagProps } from './interfaces';
 import styles from './style.css';
@@ -14,7 +14,7 @@ function MenteeRow({ mentee, programState }: StatusTagProps) {
   const actions: ReactNode[] = [];
   const [menteeState, setMenteeState] = useState(mentee.state);
 
-  const updateMenteeState = (isApproved: boolean) => {
+  const updateMenteeState = async (isApproved: boolean) => {
     let successMessage = '';
     let errorMessage = '';
 
@@ -26,33 +26,20 @@ function MenteeRow({ mentee, programState }: StatusTagProps) {
       errorMessage = "Couldn't reject the mentee";
     }
 
-    axios
-      .put(
-        `${API_URL}/mentees/${mentee.id}/state`,
-        {
-          isApproved: isApproved,
-        },
-        {
-          withCredentials: true,
-        }
-      )
-      .then((result: AxiosResponse<Mentee>) => {
-        if (result.status == 200) {
-          setMenteeState(result.data.state);
-          notification.success({
-            message: 'Success!',
-            description: successMessage,
-          });
-        } else {
-          throw new Error();
-        }
-      })
-      .catch(() => {
-        notification.error({
-          message: 'Error!',
-          description: errorMessage,
-        });
+    const response: AxiosResponse<Mentee> = await updateStateOfMenteeApplication(
+      mentee.id,
+      isApproved,
+      errorMessage
+    );
+    if (response.status == 200) {
+      setMenteeState(response.data.state);
+      notification.success({
+        message: 'Success!',
+        description: successMessage,
       });
+    } else {
+      throw new Error();
+    }
   };
 
   const confirmRejection = () => {

--- a/src/scenes/Home/scenes/RequestMentors/scenes/MenteeApplication/index.tsx
+++ b/src/scenes/Home/scenes/RequestMentors/scenes/MenteeApplication/index.tsx
@@ -136,19 +136,19 @@ function MenteeApplication() {
         <Spin tip="Loading..." spinning={isLoading}>
           <Row>
             <Col offset={1} span={1}>
-              <Avatar size={64} src={mentor.profile.imageUrl} />
+              <Avatar size={64} src={mentor?.profile.imageUrl} />
             </Col>
             <Col offset={1}>
               <Title level={3}>
-                {mentor.profile.firstName} {mentor.profile.lastName}
+                {mentor?.profile.firstName} {mentor?.profile.lastName}
               </Title>
-              <Text>{mentor.profile.headline}</Text>
+              <Text>{mentor?.profile.headline}</Text>
             </Col>
           </Row>
           <div className={styles.contentMargin}>
-            <a href={mentor.profile.linkedinUrl}>
+            <a href={mentor?.profile.linkedinUrl}>
               <LinkedinOutlined />
-              {''} {mentor.profile.firstName}&apos;s LinkedIn profile
+              {''} {mentor?.profile.firstName}&apos;s LinkedIn profile
             </a>
             <br />
             <br />

--- a/src/util/mentee-services.ts
+++ b/src/util/mentee-services.ts
@@ -1,0 +1,90 @@
+import { notification } from 'antd';
+import axios, { AxiosResponse, Method } from 'axios';
+
+import { API_URL } from '../constants';
+import { Mentee } from '../types';
+
+/**
+ * API call to get details if a mentee has requested for a mentor
+ * @param mentorId : mentor id that the mentee has requested for
+ */
+export const getMenteeApplication = async (mentorId: string) => {
+  let mentee: Mentee;
+  try {
+    const result: AxiosResponse<Mentee> = await axios.get(
+      `${API_URL}/mentors/${mentorId}/mentee`,
+      {
+        withCredentials: true,
+      }
+    );
+    if (result.status === 200) {
+      mentee = result.data;
+    }
+  } catch (e) {
+    notification.error({
+      message: 'Warning!',
+      description: 'Failed to fetch mentee',
+    });
+  }
+  return mentee;
+};
+
+/**
+ * API call to request for a mentor
+ * @param mentorId: id of the mentor being requested
+ * @param method: axios method to be called
+ * @param submissionUrl: application url
+ */
+export const requestForAMentor = async (
+  mentorId: string,
+  method: Method,
+  submissionUrl: string
+) => {
+  let result: AxiosResponse<Mentee>;
+  try {
+    const response = await axios({
+      method: method,
+      url: `${API_URL}/mentors/${mentorId}/mentee`,
+      data: { submissionUrl },
+      withCredentials: true,
+    });
+    result = response;
+  } catch (e) {
+    console.error(e);
+    notification.error({
+      message: 'Error',
+      description: 'Something went wrong when requesting the mentor',
+    });
+  }
+  return result;
+};
+
+/**
+ * API call to update the state of a mentee application
+ * @param menteeId: the id of the mentee whose status is updated
+ * @param isApproved: if the application was approved previously
+ * @param errorMessage: error message to be displayed
+ */
+export const updateStateOfMenteeApplication = async (
+  menteeId: number,
+  isApproved: boolean,
+  errorMessage: string
+) => {
+  let result: AxiosResponse<Mentee>;
+  try {
+    const response: AxiosResponse<Mentee> = await axios.put(
+      `${API_URL}/mentees/${menteeId}/state`,
+      {
+        isApproved,
+      },
+      { withCredentials: true }
+    );
+    result = response;
+  } catch (e) {
+    notification.error({
+      message: 'Error!',
+      description: errorMessage,
+    });
+  }
+  return result;
+};

--- a/src/util/mentor-services.ts
+++ b/src/util/mentor-services.ts
@@ -1,9 +1,44 @@
 import { notification } from 'antd';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 import { API_URL } from '../constants';
-import { Application, UpdateQuestion } from '../types';
+import { Application, Mentor, UpdateQuestion } from '../types';
 
+/**
+ * API call to get the details of a particular mentor
+ * @param mentorId : the mentor id of the mentor required
+ */
+export const getMentor = async (mentorId: string) => {
+  let mentor: Mentor;
+  try {
+    const result: AxiosResponse<Mentor> = await axios.get(
+      `${API_URL}/mentors/${mentorId}`,
+      {
+        withCredentials: true,
+      }
+    );
+    if (result.status === 200) {
+      mentor = result.data;
+    } else {
+      notification.error({
+        message: 'Error!',
+        description: 'Something went wrong when fetching the mentor',
+      });
+    }
+  } catch (error) {
+    notification.error({
+      message: 'Error!',
+      description: 'Something went wrong when fetching the mentor',
+    });
+  }
+  return mentor;
+};
+
+/**
+ * API call to apply as a mentor to a program
+ * @param application : form data from application
+ * @param programId : id of the program mentor is applying to
+ */
 export const applyForProgram = async (
   application: Application[],
   programId: string
@@ -35,6 +70,10 @@ export const applyForProgram = async (
   }
 };
 
+/**
+ * API call to receive responses given by a mentor to a program
+ * @param programId : program id of the program selected
+ */
 export const getResponses = async (programId: string) => {
   try {
     const result = await axios.get(
@@ -58,6 +97,11 @@ export const getResponses = async (programId: string) => {
   }
 };
 
+/**
+ * API call to update the mentor application for a program
+ * @param programId
+ * @param application : form data from the program application
+ */
 export const updateApplication = async (
   programId: string,
   application: UpdateQuestion[]


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix #191 

## Goals
To migrate all mentee related API calls to a separate utility file

## Approach
Removed axios calls related to mentees from all components and moved them to a separate utility file called mentee-services

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Test environment
Windows 10
Google Chrome
