### PR TITLE
Add a delete confirmation popup when deleting the comments

### DIFF
--- a/src/components/CommentSection/index.tsx
+++ b/src/components/CommentSection/index.tsx
@@ -125,9 +125,20 @@ function CommentSection({ mentee }: { mentee: Mentee }) {
                         <Popover
                           placement="top"
                           content={
-                            <a onClick={() => deleteComment(comment.id)}>
-                              Delete
-                            </a>
+                            <div>
+                              <a
+                                className={styles.popoverButton}
+                                onClick={() => deleteComment(comment.id)}
+                              >
+                                Yes
+                              </a>
+                              <a
+                                className={styles.popoverButton}
+                                onClick={window.close}
+                              >
+                                No
+                              </a>
+                            </div>
                           }
                           title="Are you sure you want to delete this comment?"
                         >

--- a/src/components/CommentSection/index.tsx
+++ b/src/components/CommentSection/index.tsx
@@ -4,6 +4,7 @@ import { DeleteOutlined, MoreOutlined } from '@ant-design/icons';
 import {
   Avatar,
   Button,
+  Popover,
   Divider,
   Typography,
   Input,
@@ -121,13 +122,20 @@ function CommentSection({ mentee }: { mentee: Mentee }) {
                   overlay={
                     <Menu>
                       <Menu.Item>
-                        <Button
-                          type="text"
-                          onClick={() => deleteComment(comment.id)}
+                        <Popover
+                          placement="top"
+                          content={
+                            <a onClick={() => deleteComment(comment.id)}>
+                              Delete
+                            </a>
+                          }
+                          title="Are you sure you want to delete this comment?"
                         >
-                          <DeleteOutlined className={styles.deleteBtn} />
-                          Delete Comment
-                        </Button>
+                          <Button type="text">
+                            <DeleteOutlined className={styles.deleteBtn} />
+                            Delete
+                          </Button>
+                        </Popover>
                       </Menu.Item>
                     </Menu>
                   }

--- a/src/components/CommentSection/style.css
+++ b/src/components/CommentSection/style.css
@@ -12,3 +12,8 @@
 .deleteBtn {
   color: red;
 }
+
+.popoverButton{
+  padding: 2px 5px 2px 5px;
+  margin: 0px 5px 0px 5px;
+}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #298 

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
- Add a popover when deleting comments.

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Use ant design popover component.

## Screenshots
<!--- Attach screenshots or demo-gif of any UI changes -->
https://user-images.githubusercontent.com/27630091/152652556-74a625d8-4d86-4f88-bf31-d14e21040c4f.mov


##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


## Test environment
<!--- List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
- OS: macOS Monterey
- Browser: Safari 14.0.1
- IDE: Visual Studio Code